### PR TITLE
feat: improve template creation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+package-lock.json

--- a/src/context.jsx
+++ b/src/context.jsx
@@ -28,7 +28,9 @@ export function AppProvider({ children }) {
     updateSet: (setId, patch) => { api.updateSet(setId, patch); setState(api.bootstrap()) },
     deleteSet: (setId) => { api.deleteSet(setId); setState(api.bootstrap()) },
     createTemplateFromSession: (sessionId, name) => {
-      api.createTemplateFromSession(sessionId, name); setState(api.bootstrap())
+      const id = api.createTemplateFromSession(sessionId, name)
+      setState(api.bootstrap())
+      return id
     },
     applyTemplate: (templateId, date) => {
       const id = api.applyTemplate(templateId, date); setState(api.bootstrap()); return id

--- a/src/lib/api.js
+++ b/src/lib/api.js
@@ -89,9 +89,22 @@ export function deleteSet(id){
 export function createTemplateFromSession(sessionId, name){
   const t = { id: uid(), user_id: db.user.id, name, description: '', created_at: Date.now(), updated_at: Date.now() }
   db.templates.push(t)
-  const ses = db.sessionExercises.filter(se=>se.session_id===sessionId).sort((a,b)=>a.order_index-b.order_index)
+  const ses = db.sessionExercises
+    .filter(se=>se.session_id===sessionId)
+    .sort((a,b)=>a.order_index-b.order_index)
   ses.forEach((se, idx)=>{
-    const te = { id: uid(), template_id: t.id, exercise_id: se.exercise_id, default_sets: 3, default_reps: 10, default_weight: null, order_index: idx }
+    const sets = db.sets
+      .filter(st=>st.session_exercise_id===se.id)
+      .sort((a,b)=>a.set_index-b.set_index)
+    const te = {
+      id: uid(),
+      template_id: t.id,
+      exercise_id: se.exercise_id,
+      default_sets: sets.length || 1,
+      default_reps: sets[0]?.reps || 10,
+      default_weight: sets[0]?.weight ?? null,
+      order_index: idx
+    }
     db.templateExercises.push(te)
   })
   persist(); return t.id


### PR DESCRIPTION
## Summary
- clone session sets into templates so default reps/weight reflect source session
- return template id from context creation helper
- ignore node modules in git

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_689743fc5ac8832ba636f48066cd0875